### PR TITLE
Add more sorting, bytes fmt, result info

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ enum SortType {
     /// Sort by number of copies.
     Copies,
 
-    // Sort by function size.
+    /// Sort by function size.
     Size,
 }
 


### PR DESCRIPTION
Includes a few changes, happy to remove or change any of them :)

### Sorting options

From `--help`

```
--sort <SORT>
    What to sort results by
    
    [default: excess-bytes]

    Possible values:
    - excess-bytes: Sort by excess bytes of function in the binary
    - copies:       Sort by number of copies
    - size:         Sort by function size
```

### Bytes formatting

This one is a little opinionated, open to also showing actual bytes next to the KB/MB. Personally I think it makes the results much easier to parse at a glance.

```
Function size: 2.3KiB
Copies: 6
Excess bytes: 11.3KiB
```

### Result info

Adds original binary size in addition to excess bytes amount. Also lists number of functions with dupes, and the number of excess instances.

```
Original binary: 3.1MiB
   Excess bytes: 304.3KiB (9.6%)
            Fns: 458 with dupes, 1651 excess instances
```

### Bin arg

Changes the binary argument in clap from an option to an "argument". Changes how the `--help` is laid out and allows you to supply the binary as the final argument without needing to prefix it with `--bin`.
